### PR TITLE
Feature(backend): Track root + dev + delivered flags

### DIFF
--- a/src/main/java/com/philips/research/bombar/controller/DependencyJson.java
+++ b/src/main/java/com/philips/research/bombar/controller/DependencyJson.java
@@ -22,8 +22,10 @@ class DependencyJson {
     @NullOr String relation;
     @JsonProperty("package")
     @NullOr PackageJson pkg;
-    boolean source;
     int issues;
+    boolean isRoot;
+    boolean isDevelopment;
+    boolean isDelivered;
     @NullOr List<String> licenseIssues;
     @NullOr List<DependencyJson> dependencies;
     @NullOr List<DependencyJson> usages;
@@ -41,8 +43,10 @@ class DependencyJson {
         this.relation = dto.relation;
         this.license = dto.license;
         this.pkg = PackageJson.fromDto(dto.pkg);
-        this.source = dto.source;
         this.issues = dto.issues;
+        this.isRoot = dto.isRoot;
+        this.isDevelopment = dto.isDevelopment;
+        this.isDelivered = dto.isDelivered;
         this.licenseIssues = dto.violations;
         this.dependencies = toList(dto.dependencies);
         this.usages = toList(dto.usages);

--- a/src/main/java/com/philips/research/bombar/controller/ProjectsRoute.java
+++ b/src/main/java/com/philips/research/bombar/controller/ProjectsRoute.java
@@ -73,16 +73,6 @@ public class ProjectsRoute extends BaseRoute {
         return new DependencyJson(result);
     }
 
-    @PostMapping("{projectId}/dependencies/{dependencyId}/source")
-    public void setPackageSource(@PathVariable UUID projectId, @PathVariable String dependencyId) {
-        projectService.setSourcePackage(projectId, dependencyId, true);
-    }
-
-    @DeleteMapping("{projectId}/dependencies/{dependencyId}/source")
-    public void resetPackageSource(@PathVariable UUID projectId, @PathVariable String dependencyId) {
-        projectService.setSourcePackage(projectId, dependencyId, false);
-    }
-
     @PostMapping("{projectId}/dependencies/{dependencyId}/exempt")
     public void exempt(@PathVariable UUID projectId, @PathVariable String dependencyId, @RequestBody ExemptionJson body) {
         projectService.exempt(projectId, dependencyId, body.rationale);

--- a/src/main/java/com/philips/research/bombar/core/ProjectService.java
+++ b/src/main/java/com/philips/research/bombar/core/ProjectService.java
@@ -59,14 +59,6 @@ public interface ProjectService {
     DependencyDto getDependency(UUID projectId, String dependencyId);
 
     /**
-     * Marks a project dependency as the source for a package version.
-     *
-     * @param projectId    project of the dependency
-     * @param dependencyId dependency in the project
-     */
-    void setSourcePackage(UUID projectId, String dependencyId, boolean isSource);
-
-    /**
      * Suppress violations for dependency.
      *
      * @param dependencyId reference of dependency
@@ -112,8 +104,10 @@ public interface ProjectService {
         public @NullOr String license;
         public @NullOr String relation;
         public PackageService.@NullOr PackageDto pkg;
-        public boolean source;
         public int issues;
+        public boolean isRoot;
+        public boolean isDevelopment;
+        public boolean isDelivered;
         public @NullOr List<String> violations;
         public @NullOr List<DependencyDto> dependencies;
         public @NullOr List<DependencyDto> usages;

--- a/src/main/java/com/philips/research/bombar/core/domain/Dependency.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/Dependency.java
@@ -20,7 +20,9 @@ public class Dependency {
     private @NullOr Package pkg;
     private String version = "";
     private String license = "";
-    private boolean packageSource;
+    private boolean isRoot;
+    private boolean isDevelopment;
+    private boolean isDelivered;
     private int issueCount;
     private @NullOr String exemption;
 
@@ -84,15 +86,31 @@ public class Dependency {
                 .collect(Collectors.toList());
     }
 
-    public boolean isPackageSource() {
-        return packageSource;
+    public boolean isRoot() {
+        return this.isRoot;
     }
 
-    public Dependency setPackageSource(boolean packageSource) {
-        if (pkg == null) {
-            throw new DomainException("Dependency " + this + " has no package definition");
-        }
-        this.packageSource = packageSource;
+    public Dependency setRoot() {
+        this.isRoot = true;
+        this.isDelivered= true;
+        return this;
+    }
+
+    public boolean isDevelopment() {
+        return isDevelopment;
+    }
+
+    Dependency setDevelopment() {
+        isDevelopment = true;
+        return this;
+    }
+
+    public boolean isDelivered() {
+        return isDelivered;
+    }
+
+    Dependency setDelivered() {
+        isDelivered = true;
         return this;
     }
 

--- a/src/main/java/com/philips/research/bombar/core/domain/DtoConverter.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/DtoConverter.java
@@ -61,8 +61,10 @@ abstract class DtoConverter {
         dto.title = dependency.getTitle();
         dto.version = dependency.getVersion();
         dto.license = dependency.getLicense();
-        dto.source = dependency.isPackageSource();
         dto.issues = dependency.getIssueCount();
+        dto.isRoot = dependency.isRoot();
+        dto.isDevelopment = dependency.isDevelopment();
+        dto.isDelivered = dependency.isDelivered();
         dependency.getExemption().ifPresent(rationale -> dto.exemption = rationale);
         return dto;
     }

--- a/src/main/java/com/philips/research/bombar/core/domain/Project.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/Project.java
@@ -14,7 +14,6 @@ import java.util.*;
 public class Project {
     private final UUID uuid;
     private final Map<String, Dependency> dependencies = new HashMap<>();
-    private final Set<Package> packageSources = new HashSet<>();
     // Key is package reference, value is rationale of exemption
     private final Map<URI, String> packageExemptions = new HashMap<>();
     private String title = "";
@@ -68,22 +67,6 @@ public class Project {
         return this;
     }
 
-    public void addPackageSource(Package pkg) {
-        packageSources.add(pkg);
-        updatePackageSources(pkg, true);
-    }
-
-    public void removePackageSource(Package pkg) {
-        packageSources.remove(pkg);
-        updatePackageSources(pkg, false);
-    }
-
-    private void updatePackageSources(Package pkg, boolean value) {
-        dependencies.values().stream()
-                .filter(dep -> dep.getPackage().stream().anyMatch(p -> p.equals(pkg)))
-                .forEach(dep -> dep.setPackageSource(value));
-    }
-
     public Collection<Dependency> getRootDependencies() {
         final var roots = new ArrayList<>(dependencies.values());
         dependencies.values().stream()
@@ -105,19 +88,9 @@ public class Project {
         if (dependencies.containsKey(id)) {
             throw new DomainException(String.format("Project %s contains duplicate dependency %s", this.uuid, id));
         }
-        markAsPackageSource(dependency);
         setExemptions(dependency);
         dependencies.put(id, dependency);
         return this;
-    }
-
-    private void markAsPackageSource(Dependency dependency) {
-        if (dependency.getPackage().isPresent()) {
-            final var pkg = dependency.getPackage().get();
-            if (packageSources.contains(pkg)) {
-                dependency.setPackageSource(true);
-            }
-        }
     }
 
     private void setExemptions(Dependency dependency) {

--- a/src/main/java/com/philips/research/bombar/core/domain/ProjectInteractor.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/ProjectInteractor.java
@@ -119,20 +119,6 @@ public class ProjectInteractor implements ProjectService {
     }
 
     @Override
-    public void setSourcePackage(UUID projectId, String dependencyId, boolean isSource) {
-        final var project = validProject(projectId);
-        project.getDependency(dependencyId)
-                .flatMap(Dependency::getPackage)
-                .ifPresent(pkg -> {
-                    if (isSource) {
-                        project.addPackageSource(pkg);
-                    } else {
-                        project.removePackageSource(pkg);
-                    }
-                });
-    }
-
-    @Override
     public void exempt(UUID projectId, String dependencyId, @NullOr String rationale) {
         final var project = validProject(projectId);
         final var dependency = validDependency(project, dependencyId);

--- a/src/main/java/com/philips/research/bombar/core/domain/Relation.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/Relation.java
@@ -12,15 +12,20 @@ public class Relation {
     private final Dependency target;
 
     // Necessary for persistence
-    @SuppressWarnings("unused")
+    @SuppressWarnings({"unused", "ConstantConditions"})
     protected Relation() {
-        //noinspection ConstantConditions
-        this(null, null);
+        this.type = null;
+        this.target = null;
     }
 
     public Relation(Relationship type, Dependency target) {
         this.type = type;
         this.target = target;
+        if (type == Relationship.IRRELEVANT) {
+            target.setDevelopment();
+        } else {
+            target.setDelivered();
+        }
     }
 
     public Relationship getType() {

--- a/src/main/java/com/philips/research/bombar/core/spdx/SpdxParser.java
+++ b/src/main/java/com/philips/research/bombar/core/spdx/SpdxParser.java
@@ -199,6 +199,7 @@ public class SpdxParser {
         mergeCurrent();
         applyRelationShips();
         applyCustomLicenses();
+        markRoots();
     }
 
     private void mergeCurrent() {
@@ -234,6 +235,10 @@ public class SpdxParser {
                     .replaceAll(id -> "\"" + customLicenseNames.getOrDefault(id.group(), id.group()) + "\"");
             dependency.setLicense(expanded);
         });
+    }
+
+    private void markRoots() {
+        project.getRootDependencies().forEach(Dependency::setRoot);
     }
 
     private class SpdxPackage {

--- a/src/main/resources/META-INF/orm.xml
+++ b/src/main/resources/META-INF/orm.xml
@@ -57,12 +57,6 @@
                 <join-column name="project_id"/>
                 <cascade/>
             </one-to-many>
-            <many-to-many name="packageSources" target-entity="com.philips.research.bombar.persistence.PackageEntity">
-                <join-table name="package_sources">
-                    <join-column name="project_id"/>
-                    <inverse-join-column name="package_id"/>
-                </join-table>
-            </many-to-many>
             <element-collection name="packageExemptions">
                 <map-key-class class="java.net.URI"/>
                 <map-key-column name="package_ref" nullable="false"/>
@@ -86,8 +80,14 @@
                 <column nullable="false"/>
                 <lob/>
             </basic>
-            <basic name="packageSource" optional="false">
-                <column name="is_source" nullable="false"/>
+            <basic name="isRoot" optional="false">
+                <column name="is_root" nullable="false"/>
+            </basic>
+            <basic name="isDevelopment" optional="false">
+                <column name="is_development" nullable="false"/>
+            </basic>
+            <basic name="isDelivered" optional="false">
+                <column name="is_delivered" nullable="false"/>
             </basic>
             <basic name="exemption" optional="true">
                 <column nullable="true"/>

--- a/src/main/resources/db/migration/V4__Add dependency flags.sql
+++ b/src/main/resources/db/migration/V4__Add dependency flags.sql
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlResolveForFile
+
+ALTER TABLE dependencies
+    ADD COLUMN is_root BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE dependencies
+    ADD COLUMN is_development BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE dependencies
+    ADD COLUMN is_delivered BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE dependencies DROP COLUMN is_source;
+
+DROP TABLE package_sources;

--- a/src/test/java/com/philips/research/bombar/controller/DependencyJsonTest.java
+++ b/src/test/java/com/philips/research/bombar/controller/DependencyJsonTest.java
@@ -33,25 +33,30 @@ class DependencyJsonTest {
             dto.title = TITLE;
             dto.purl = PURL;
             dto.license = LICENSE;
+            dto.isRoot = true;
+            dto.isDevelopment = true;
+            dto.isDelivered = true;
             dto.relation = RELATION;
             dto.pkg = new PackageService.PackageDto();
             dto.pkg.reference = REFERENCE;
             dto.pkg.approval = PackageService.Approval.CONTEXT;
             dto.exemption = RATIONALE;
-            dto.source = true;
 
             final var json = new DependencyJson(dto);
 
             assertThat(json.id).isEqualTo(ID);
             assertThat(json.title).isEqualTo(TITLE);
             assertThat(json.purl).isEqualTo(PURL);
+            assertThat(json.license).isEqualTo(LICENSE);
+            assertThat(json.isRoot).isTrue();
+            assertThat(json.isDevelopment).isTrue();
+            assertThat(json.isDelivered).isTrue();
             assertThat(json.relation).isEqualTo(RELATION);
             assertThat(json.dependencies).isNull();
             assertThat(json.usages).isNull();
             //noinspection ConstantConditions
             assertThat(json.pkg).isNotNull();
             assertThat(json.exemption).isEqualTo(RATIONALE);
-            assertThat(json.source).isTrue();
         }
 
         @Test

--- a/src/test/java/com/philips/research/bombar/controller/ProjectsRouteTest.java
+++ b/src/test/java/com/philips/research/bombar/controller/ProjectsRouteTest.java
@@ -147,22 +147,6 @@ class ProjectsRouteTest {
     }
 
     @Test
-    void setsDependencyAsPackageSource() throws Exception {
-        mvc.perform(post(PACKAGE_SOURCE_URL, PROJECT_ID, DEPENDENCY_ID))
-                .andExpect(status().isOk());
-
-        verify(service).setSourcePackage(PROJECT_ID, DEPENDENCY_ID, true);
-    }
-
-    @Test
-    void resetsDependencyAsPackageSource() throws Exception {
-        mvc.perform(delete(PACKAGE_SOURCE_URL, PROJECT_ID, DEPENDENCY_ID))
-                .andExpect(status().isOk());
-
-        verify(service).setSourcePackage(PROJECT_ID, DEPENDENCY_ID, false);
-    }
-
-    @Test
     void exemptsDependency() throws Exception {
         mvc.perform(post(EXEMPTION_URL, PROJECT_ID, DEPENDENCY_ID)
                 .content(new JSONObject().put("rationale", RATIONALE).toString())

--- a/src/test/java/com/philips/research/bombar/core/domain/DependencyTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/DependencyTest.java
@@ -33,6 +33,9 @@ class DependencyTest {
         assertThat(dependency.getVersion()).isEmpty();
         assertThat(dependency.getPackageUrl()).isEmpty();
         assertThat(dependency.getLicense()).isEmpty();
+        assertThat(dependency.isRoot()).isFalse();
+        assertThat(dependency.isDevelopment()).isFalse();
+        assertThat(dependency.isDelivered()).isFalse();
         assertThat(dependency.getRelations()).isEmpty();
         assertThat(dependency.getUsages()).isEmpty();
         assertThat(dependency.getExemption()).isEmpty();
@@ -91,19 +94,25 @@ class DependencyTest {
     }
 
     @Test
-    void updatesSourcePackageStatus() {
-        dependency.setPackage(PACKAGE);
+    void updatesRootStatus() {
+       dependency.setRoot() ;
 
-        dependency.setPackageSource(true);
-
-        assertThat(dependency.isPackageSource()).isTrue();
+       assertThat(dependency.isRoot()).isTrue();
+        assertThat(dependency.isDelivered()).isTrue();
     }
 
     @Test
-    void throws_setSourceButNoPackage() {
-        assertThatThrownBy(() -> dependency.setPackageSource(true))
-                .isInstanceOf(DomainException.class)
-                .hasMessageContaining("no package definition");
+    void updatesDevelopmentStatus() {
+       dependency.setDevelopment() ;
+
+       assertThat(dependency.isDevelopment()).isTrue();
+    }
+
+    @Test
+    void updatesDeliveryStatus() {
+        dependency.setDelivered();
+
+        assertThat(dependency.isDelivered()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/philips/research/bombar/core/domain/ProjectInteractorTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/ProjectInteractorTest.java
@@ -209,28 +209,6 @@ class ProjectInteractorTest {
         }
 
         @Nested
-        class PackageSourceTracking {
-            @Test
-            void marksDependencyAsPackageSource() {
-                dependency.setPackage(PACKAGE);
-
-                interactor.setSourcePackage(PROJECT_ID, DEPENDENCY_ID, true);
-
-                assertThat(dependency.isPackageSource()).isTrue();
-            }
-
-            @Test
-            void clearsDependencyAsPackageSource() {
-                dependency.setPackage(PACKAGE);
-                project.addPackageSource(PACKAGE);
-
-                interactor.setSourcePackage(PROJECT_ID, DEPENDENCY_ID, false);
-
-                assertThat(dependency.isPackageSource()).isFalse();
-            }
-        }
-
-        @Nested
         class SpdxImport {
             @Test
             void throws_importForUnknownProject() {

--- a/src/test/java/com/philips/research/bombar/core/domain/ProjectTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/ProjectTest.java
@@ -150,46 +150,4 @@ class ProjectTest {
             assertThat(dependency.getExemption()).contains(RATIONALE);
         }
     }
-
-    @Nested
-    class PackageSources {
-        private final Dependency withPackage = new Dependency(ID, TITLE).setPackage(PACKAGE);
-        private final Dependency withOtherPackage = new Dependency("other", TITLE)
-                .setPackage(new Package(URI.create("other")));
-        private final Dependency withoutPackage = new Dependency("without", TITLE);
-
-        @BeforeEach
-        void setUp() {
-            project.addDependency(withPackage)
-                    .addDependency(withOtherPackage)
-                    .addDependency(withoutPackage);
-        }
-
-        @Test
-        void addsPackageSource() {
-            project.addPackageSource(PACKAGE);
-
-            assertThat(withPackage.isPackageSource()).isTrue();
-            assertThat(withOtherPackage.isPackageSource()).isFalse();
-            assertThat(withoutPackage.isPackageSource()).isFalse();
-        }
-
-        @Test
-        void marksNewDependency() {
-            final var dep = new Dependency("new", TITLE).setPackage(PACKAGE);
-            project.addPackageSource(PACKAGE);
-
-            project.addDependency(dep);
-
-            assertThat(dep.isPackageSource()).isTrue();
-        }
-
-        @Test
-        void removesPackageSource() {
-            project.addPackageSource(PACKAGE);
-            project.removePackageSource(PACKAGE);
-
-            assertThat(withPackage.isPackageSource()).isFalse();
-        }
-    }
 }

--- a/src/test/java/com/philips/research/bombar/core/domain/RelationTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/RelationTest.java
@@ -22,6 +22,26 @@ class RelationTest {
     }
 
     @Test
+    void marksDeliveryDependency() {
+        for (var type : Relation.Relationship.values()) {
+            if (type != Relation.Relationship.IRRELEVANT) {
+                new Relation(type, dependency);
+            }
+        }
+
+        assertThat(dependency.isDelivered()).isTrue();
+        assertThat(dependency.isDevelopment()).isFalse();
+    }
+
+    @Test
+    void marksDevelopmentDependency() {
+        new Relation(Relation.Relationship.IRRELEVANT, dependency);
+
+        assertThat(dependency.isDevelopment()).isTrue();
+        assertThat(dependency.isDelivered()).isFalse();
+    }
+
+    @Test
     void implementsEquals() {
         EqualsVerifier.forClass(Relation.class)
                 .withNonnullFields("type", "target")

--- a/src/test/java/com/philips/research/bombar/core/spdx/SpdxParserTest.java
+++ b/src/test/java/com/philips/research/bombar/core/spdx/SpdxParserTest.java
@@ -204,6 +204,8 @@ class SpdxParserTest {
             assertThat(relation.getTarget()).isEqualTo(child);
             assertThat(child.getUsages()).contains(parent);
             assertThat(parent.getUsages()).isEmpty();
+            assertThat(parent.isRoot()).isTrue();
+            assertThat(child.isRoot()).isFalse();
         }
 
         @Test
@@ -223,6 +225,8 @@ class SpdxParserTest {
             assertThat(parent.getRelations()).hasSize(1);
             var relation = parent.getRelations().stream().findFirst().orElseThrow();
             assertThat(relation.getTarget()).isEqualTo(child);
+            assertThat(parent.isRoot()).isTrue();
+            assertThat(child.isRoot()).isFalse();
         }
 
         @Test

--- a/src/test/java/com/philips/research/bombar/persistence/PersistentDatabaseTest.java
+++ b/src/test/java/com/philips/research/bombar/persistence/PersistentDatabaseTest.java
@@ -74,44 +74,6 @@ class PersistentDatabaseTest {
     }
 
     @Test
-    void storesPackageSourcesPerProject() {
-        final var project = database.createProject();
-        final var pkg = database.createPackageDefinition(REFERENCE);
-        project.addPackageSource(pkg);
-        flushEntityManager();
-
-        //noinspection OptionalGetWithoutIsPresent
-        final var storedProject = database.getProject(project.getId()).get();
-        //noinspection OptionalGetWithoutIsPresent
-        final var storedPkg = database.getPackageDefinition(REFERENCE).get();
-
-        final var dependency = database.createDependency(project, DEPENDENCY_ID, TITLE);
-        storedProject.addDependency(dependency.setPackage(storedPkg));
-        assertThat(dependency.isPackageSource()).isTrue();
-    }
-
-    @Test
-    void removesPackageSourceFromProjectWithoutDeletingPackage() {
-        final var project = database.createProject();
-        final var pkg = database.createPackageDefinition(REFERENCE);
-        project.addPackageSource(pkg);
-        flushEntityManager();
-
-        //noinspection OptionalGetWithoutIsPresent
-        final var storedProject = database.getProject(project.getId()).get();
-        //noinspection OptionalGetWithoutIsPresent
-        final var storedPkg = database.getPackageDefinition(REFERENCE).get();
-        storedProject.removePackageSource(storedPkg);
-
-        final var dependency = database.createDependency(project, DEPENDENCY_ID, TITLE);
-        storedProject.addDependency(dependency.setPackage(storedPkg));
-        assertThat(dependency.isPackageSource()).isFalse();
-
-        flushEntityManager();
-        assertThat(database.getPackageDefinition(REFERENCE)).isNotEmpty();
-    }
-
-    @Test
     void storesDependencies() {
         final var project = database.createProject();
         final var dependency = database.createDependency(project, DEPENDENCY_ID, TITLE);


### PR DESCRIPTION
- Type of package is flagged using the incoming relationship.
- Root dependencies are marked after completion of the import.
- All root dependencies are by default also delivered.

Removed the "source package" handling, as manually marking inner source packages does not really make sense.