### PR TITLE
Feature/project query performance

### DIFF
--- a/src/main/java/com/philips/research/bombar/core/PersistentStore.java
+++ b/src/main/java/com/philips/research/bombar/core/PersistentStore.java
@@ -68,15 +68,6 @@ public interface PersistentStore {
     Project getProjectFor(Dependency dependency);
 
     /**
-     * Creates a new persisted dependency relation.
-     *
-     * @param type   type of the relation
-     * @param target target dependency of the relation
-     * @return a persisted relation
-     */
-    Relation createRelation(Relation.Relationship type, Dependency target);
-
-    /**
      * Lists all dependencies that map to a version of a package.
      *
      * @param pkg the package definition

--- a/src/main/java/com/philips/research/bombar/core/ProjectService.java
+++ b/src/main/java/com/philips/research/bombar/core/ProjectService.java
@@ -62,7 +62,7 @@ public interface ProjectService {
      * Suppress violations for dependency.
      *
      * @param dependencyId reference of dependency
-     * @param rationale Explanation, or <code>null</code> to remove exemption
+     * @param rationale    Explanation, or <code>null</code> to remove exemption
      */
     void exempt(UUID projectId, String dependencyId, @NullOr String rationale);
 

--- a/src/main/java/com/philips/research/bombar/core/domain/Dependency.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/Dependency.java
@@ -18,6 +18,7 @@ public class Dependency {
     private final Set<Dependency> usages = new HashSet<>();
 
     private @NullOr Package pkg;
+    private @NullOr URI purl;
     private String version = "";
     private String license = "";
     private boolean isRoot;
@@ -39,6 +40,15 @@ public class Dependency {
         return title;
     }
 
+    public Optional<URI> getPurl() {
+        return Optional.ofNullable(purl);
+    }
+
+    public Dependency setPurl(Purl purl) {
+        this.purl = purl.toUri();
+        return this;
+    }
+
     public Optional<Package> getPackage() {
         return Optional.ofNullable(pkg);
     }
@@ -50,11 +60,6 @@ public class Dependency {
 
     public Optional<URI> getPackageReference() {
         return Optional.ofNullable((pkg != null) ? pkg.getReference() : null);
-    }
-
-    public Optional<URI> getPackageUrl() {
-        return getPackage()
-                .map(pkg -> URI.create("pkg:" + pkg.getReference() + (!version.isBlank() ? '@' + version : "")));
     }
 
     public String getVersion() {
@@ -92,7 +97,7 @@ public class Dependency {
 
     public Dependency setRoot() {
         this.isRoot = true;
-        this.isDelivered= true;
+        this.isDelivered = true;
         return this;
     }
 

--- a/src/main/java/com/philips/research/bombar/core/domain/Dependency.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/Dependency.java
@@ -132,7 +132,7 @@ public class Dependency {
         return relations;
     }
 
-    public Dependency addRelation(Relation relation) {
+    Dependency addRelation(Relation relation) {
         relations.add(relation);
         return this;
     }
@@ -141,7 +141,7 @@ public class Dependency {
         return usages;
     }
 
-    public Dependency addUsage(Dependency dependency) {
+    Dependency addUsage(Dependency dependency) {
         this.usages.add(dependency);
         return this;
     }

--- a/src/main/java/com/philips/research/bombar/core/domain/DtoConverter.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/DtoConverter.java
@@ -6,7 +6,9 @@
 package com.philips.research.bombar.core.domain;
 
 import com.philips.research.bombar.core.PackageService;
-import com.philips.research.bombar.core.ProjectService;
+import com.philips.research.bombar.core.PackageService.PackageDto;
+import com.philips.research.bombar.core.ProjectService.DependencyDto;
+import com.philips.research.bombar.core.ProjectService.ProjectDto;
 import com.philips.research.bombar.core.domain.licenses.LicenseViolation;
 
 import java.util.Collections;
@@ -14,7 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 abstract class DtoConverter {
-    static ProjectService.ProjectDto toDto(Project project) {
+    static ProjectDto toDto(Project project) {
         final var dto = toBaseDto(project);
         dto.packages = project.getDependencies().stream()
                 .map(DtoConverter::toBaseDto)
@@ -23,8 +25,8 @@ abstract class DtoConverter {
         return dto;
     }
 
-    static ProjectService.ProjectDto toBaseDto(Project project) {
-        final var dto = new ProjectService.ProjectDto(project.getId());
+    static ProjectDto toBaseDto(Project project) {
+        final var dto = new ProjectDto(project.getId());
         dto.title = project.getTitle();
         dto.updated = project.getLastUpdate().orElse(null);
         dto.distribution = project.getDistribution().name();
@@ -33,7 +35,7 @@ abstract class DtoConverter {
         return dto;
     }
 
-    static ProjectService.DependencyDto toDto(Dependency dependency, List<LicenseViolation> violations) {
+    static DependencyDto toDto(Dependency dependency, List<LicenseViolation> violations) {
         final var dto = toBaseDto(dependency);
         dependency.getPackage().ifPresent(pkg -> dto.pkg = toDto(pkg));
         dto.violations = violations.stream().map(LicenseViolation::getMessage).collect(Collectors.toList());
@@ -49,14 +51,14 @@ abstract class DtoConverter {
         return dto;
     }
 
-    static ProjectService.DependencyDto toDto(Relation relation) {
+    static DependencyDto toDto(Relation relation) {
         final var dto = toBaseDto(relation.getTarget());
         dto.relation = relation.getType().name().toLowerCase();
         return dto;
     }
 
-    public static ProjectService.DependencyDto toBaseDto(Dependency dependency) {
-        final var dto = new ProjectService.DependencyDto(dependency.getKey());
+    public static DependencyDto toBaseDto(Dependency dependency) {
+        final var dto = new DependencyDto(dependency.getKey());
         dependency.getPurl().ifPresent(purl -> dto.purl = purl);
         dto.title = dependency.getTitle();
         dto.version = dependency.getVersion();
@@ -69,12 +71,12 @@ abstract class DtoConverter {
         return dto;
     }
 
-    private static int alphabetic(ProjectService.DependencyDto l, ProjectService.DependencyDto r) {
+    private static int alphabetic(DependencyDto l, DependencyDto r) {
         return l.title.compareToIgnoreCase(r.title);
     }
 
-    public static PackageService.PackageDto toDto(Package pkg) {
-        final var dto = new PackageService.PackageDto();
+    public static PackageDto toDto(Package pkg) {
+        final var dto = new PackageDto();
         dto.reference = pkg.getReference();
         dto.name = pkg.getName();
         dto.approval = approvalOf(pkg);

--- a/src/main/java/com/philips/research/bombar/core/domain/DtoConverter.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/DtoConverter.java
@@ -57,7 +57,7 @@ abstract class DtoConverter {
 
     public static ProjectService.DependencyDto toBaseDto(Dependency dependency) {
         final var dto = new ProjectService.DependencyDto(dependency.getKey());
-        dependency.getPackageUrl().ifPresent(purl -> dto.purl = purl);
+        dependency.getPurl().ifPresent(purl -> dto.purl = purl);
         dto.title = dependency.getTitle();
         dto.version = dependency.getVersion();
         dto.license = dependency.getLicense();

--- a/src/main/java/com/philips/research/bombar/core/domain/Project.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/Project.java
@@ -101,6 +101,21 @@ public class Project {
         return this;
     }
 
+    public Project addRelationship(Dependency parent, Dependency child, Relation.Relationship relationship) {
+        validateDependency(parent);
+        validateDependency(child);
+
+        parent.addRelation(new Relation(relationship, child));
+        child.addUsage(parent);
+        return this;
+    }
+
+    private void validateDependency(Dependency dependency) {
+        if (!dependencies.containsValue(dependency)) {
+            throw new DomainException("Dependency " + dependency + " is not part of project " + this);
+        }
+    }
+
     private void setExemptions(Dependency dependency) {
         dependency.getPackageReference()
                 .flatMap(key -> Optional.ofNullable(packageExemptions.get(key)))

--- a/src/main/java/com/philips/research/bombar/core/domain/Project.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/Project.java
@@ -18,11 +18,19 @@ public class Project {
     private final Map<URI, String> packageExemptions = new HashMap<>();
     private String title = "";
     private @NullOr Instant lastUpdate;
+    private int issueCount;
     private Distribution distribution = Distribution.PROPRIETARY;
     private Phase phase = Phase.DEVELOPMENT;
 
     public Project(UUID uuid) {
         this.uuid = uuid;
+    }
+
+    public Project postProcess() {
+        issueCount = dependencies.values().stream().mapToInt(Dependency::getIssueCount).sum();
+        getRootDependencies().forEach(Dependency::setRoot);
+
+        return this;
     }
 
     public UUID getId() {
@@ -114,7 +122,7 @@ public class Project {
     }
 
     public int getIssueCount() {
-        return dependencies.values().stream().mapToInt(Dependency::getIssueCount).sum();
+        return issueCount;
     }
 
     public Phase getPhase() {

--- a/src/main/java/com/philips/research/bombar/core/domain/ProjectInteractor.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/ProjectInteractor.java
@@ -166,7 +166,7 @@ public class ProjectInteractor implements ProjectService {
     }
 
     private Dependency validDependency(Project project, String dependencyId) {
-        return  project.getDependency(dependencyId)
+        return project.getDependency(dependencyId)
                 .orElseThrow(() -> new NotFoundException("dependency", dependencyId));
     }
 }

--- a/src/main/java/com/philips/research/bombar/core/domain/Relation.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/Relation.java
@@ -18,7 +18,7 @@ public class Relation {
         this.target = null;
     }
 
-    public Relation(Relationship type, Dependency target) {
+    Relation(Relationship type, Dependency target) {
         this.type = type;
         this.target = target;
         if (type == Relationship.IRRELEVANT) {

--- a/src/main/java/com/philips/research/bombar/core/domain/licenses/LicenseChecker.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/licenses/LicenseChecker.java
@@ -40,6 +40,7 @@ public class LicenseChecker {
     public List<LicenseViolation> violations() {
         clearCaches();
         project.getRootDependencies().forEach(this::verify);
+        project.postProcess();
         return violations;
     }
 

--- a/src/main/java/com/philips/research/bombar/core/spdx/SpdxParser.java
+++ b/src/main/java/com/philips/research/bombar/core/spdx/SpdxParser.java
@@ -220,9 +220,8 @@ public class SpdxParser {
             final @NullOr Dependency to = dictionary.get(parts[reversed ? 0 : 2]);
 
             if (from != null && to != null) {
-                final var type = RELATIONSHIP_MAPPING.getOrDefault(relation.toUpperCase(), Relation.Relationship.IRRELEVANT);
-                from.addRelation(store.createRelation(type, to));
-                to.addUsage(from);
+                final var relationship = RELATIONSHIP_MAPPING.getOrDefault(relation.toUpperCase(), Relation.Relationship.IRRELEVANT);
+                project.addRelationship(from, to, relationship);
             }
         });
     }

--- a/src/main/java/com/philips/research/bombar/core/spdx/SpdxParser.java
+++ b/src/main/java/com/philips/research/bombar/core/spdx/SpdxParser.java
@@ -199,7 +199,7 @@ public class SpdxParser {
         mergeCurrent();
         applyRelationShips();
         applyCustomLicenses();
-        markRoots();
+        project.postProcess();
     }
 
     private void mergeCurrent() {
@@ -235,10 +235,6 @@ public class SpdxParser {
                     .replaceAll(id -> "\"" + customLicenseNames.getOrDefault(id.group(), id.group()) + "\"");
             dependency.setLicense(expanded);
         });
-    }
-
-    private void markRoots() {
-        project.getRootDependencies().forEach(Dependency::setRoot);
     }
 
     private class SpdxPackage {

--- a/src/main/java/com/philips/research/bombar/persistence/PersistentDatabase.java
+++ b/src/main/java/com/philips/research/bombar/persistence/PersistentDatabase.java
@@ -85,11 +85,6 @@ public class PersistentDatabase implements PersistentStore {
     }
 
     @Override
-    public Relation createRelation(Relation.Relationship type, Dependency target) {
-        return new Relation(type, target);
-    }
-
-    @Override
     public List<Dependency> findDependencies(Package pkg) {
         return new ArrayList<>(dependencyRepository.findByPkg(pkg));
     }

--- a/src/main/resources/META-INF/orm.xml
+++ b/src/main/resources/META-INF/orm.xml
@@ -93,6 +93,10 @@
                 <column nullable="true"/>
                 <lob/>
             </basic>
+            <basic name="purl" optional="true">
+                <column nullable="true"/>
+                <lob/>
+            </basic>
             <many-to-one name="pkg" fetch="LAZY"
                          target-entity="com.philips.research.bombar.persistence.PackageEntity">
                 <join-column name="package_id"/>

--- a/src/main/resources/application-db.properties
+++ b/src/main/resources/application-db.properties
@@ -7,7 +7,6 @@
 #
 # All Rights Reserved
 #
-
 # Data source definition
 spring.datasource.url=jdbc:h2:file:~/bombar_db
 spring.datasource.driverClassName=org.h2.Driver

--- a/src/main/resources/db/migration/V5__Purl in dependency.sql
+++ b/src/main/resources/db/migration/V5__Purl in dependency.sql
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlResolveForFile
+
+ALTER TABLE dependencies
+    ADD COLUMN purl CLOB;
+
+UPDATE dependencies as d
+SET purl = (SELECT reference from packages as p where p.id = d.package_id);
+UPDATE dependencies
+SET purl = CONCAT('pkg:', purl, '@', REPLACE(version, '+', '%2B'))
+WHERE purl is not null;

--- a/src/main/resources/db/migration/V6__Cache violations in project.sql
+++ b/src/main/resources/db/migration/V6__Cache violations in project.sql
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlResolveForFile
+
+ALTER TABLE projects
+    ADD COLUMN issue_count INTEGER NOT NULL DEFAULT 0;
+
+UPDATE projects
+set issue_count = (SELECT SUM(dependencies.issue_count) FROM dependencies WHERE project_id = projects.id);

--- a/src/main/resources/db/migration/V7__Populate dependency flags.sql
+++ b/src/main/resources/db/migration/V7__Populate dependency flags.sql
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2020-2021, Koninklijke Philips N.V., https://www.philips.com
+ * SPDX-License-Identifier: MIT
+ */
+
+-- noinspection SqlNoDataSourceInspectionForFile
+-- noinspection SqlResolveForFile
+
+UPDATE dependencies AS d
+SET is_root = (SELECT count(*) FROM dependency_relations AS r WHERE r.dependency_id = d.id) = 0;
+
+UPDATE dependencies AS d
+SET is_development = (SELECT count(*) FROM dependency_relations AS r WHERE r.dependency_id = d.id AND r.type = '-') > 0;
+
+UPDATE dependencies AS d
+SET is_delivered = (SELECT count(*)
+                    FROM dependency_relations AS r
+                    WHERE r.dependency_id = d.id
+                      AND r.type!='-') > 0 OR is_root;

--- a/src/test/java/com/philips/research/bombar/core/domain/DependencyTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/DependencyTest.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.Test;
 import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DependencyTest {
     private static final String ID = "Id";
     private static final String TITLE = "Title";
     private static final URI REFERENCE = URI.create("Reference");
+    private static final URI PURL = URI.create("pkg:type/ns/name@version");
     private static final Package PACKAGE = new Package(REFERENCE);
     private static final String VERSION = "Version";
     private static final String LICENSE = "License";
@@ -31,7 +31,7 @@ class DependencyTest {
         assertThat(dependency.getTitle()).isEqualTo(TITLE);
         assertThat(dependency.getPackage()).isEmpty();
         assertThat(dependency.getVersion()).isEmpty();
-        assertThat(dependency.getPackageUrl()).isEmpty();
+        assertThat(dependency.getPurl()).isEmpty();
         assertThat(dependency.getLicense()).isEmpty();
         assertThat(dependency.isRoot()).isFalse();
         assertThat(dependency.isDevelopment()).isFalse();
@@ -51,9 +51,10 @@ class DependencyTest {
     @Test
     void updatesPackage() {
         dependency.setPackage(PACKAGE);
+        dependency.setPurl(new Purl(PURL));
 
         assertThat(dependency.getPackage()).contains(PACKAGE);
-        assertThat(dependency.getPackageUrl()).contains(URI.create("pkg:" + PACKAGE.getReference()));
+        assertThat(dependency.getPurl()).contains(PURL);
     }
 
     @Test
@@ -61,15 +62,6 @@ class DependencyTest {
         dependency.setPackage(PACKAGE);
 
         assertThat(dependency.getPackageReference()).contains(REFERENCE);
-    }
-
-    @Test
-    void providesVersionedPackageUrl() {
-        dependency.setVersion(VERSION);
-        dependency.setPackage(PACKAGE);
-
-        assertThat(dependency.getPackage()).contains(PACKAGE);
-        assertThat(dependency.getPackageUrl()).contains(URI.create("pkg:" + PACKAGE.getReference() + '@' + VERSION));
     }
 
     @Test
@@ -95,17 +87,17 @@ class DependencyTest {
 
     @Test
     void updatesRootStatus() {
-       dependency.setRoot() ;
+        dependency.setRoot();
 
-       assertThat(dependency.isRoot()).isTrue();
+        assertThat(dependency.isRoot()).isTrue();
         assertThat(dependency.isDelivered()).isTrue();
     }
 
     @Test
     void updatesDevelopmentStatus() {
-       dependency.setDevelopment() ;
+        dependency.setDevelopment();
 
-       assertThat(dependency.isDevelopment()).isTrue();
+        assertThat(dependency.isDevelopment()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/philips/research/bombar/core/domain/ProjectTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/ProjectTest.java
@@ -47,15 +47,6 @@ class ProjectTest {
     }
 
     @Test
-    void tracksNumberOfIssues() {
-        project
-                .addDependency(new Dependency("Five", TITLE).setIssueCount(5))
-                .addDependency(new Dependency("Seven", TITLE).setIssueCount(7));
-
-        assertThat(project.getIssueCount()).isEqualTo(5 + 7);
-    }
-
-    @Test
     void addsDependency() {
         final var first = new Dependency("First", TITLE);
         final var second = new Dependency("Second", TITLE);
@@ -108,6 +99,30 @@ class ProjectTest {
         project.clearDependencies();
 
         assertThat(project.getDependencies()).isEmpty();
+    }
+
+    @Test
+    void marksRootsDuringPostProcessing() {
+        final var parent = new Dependency("parent", TITLE);
+        final var child = new Dependency("child", TITLE);
+        parent.addRelation(new Relation(Relation.Relationship.DYNAMIC_LINK, child));
+        project.addDependency(parent);
+        project.addDependency(child);
+
+        project.postProcess();
+
+        assertThat(parent.isRoot()).isTrue();
+        assertThat(child.isRoot()).isFalse();
+    }
+
+    @Test
+    void countsIssuesDuringPostProcessing() {
+        project.addDependency(new Dependency("1", TITLE).setIssueCount(2))
+                .addDependency(new Dependency("2", TITLE).setIssueCount(3));
+
+        project.postProcess();
+
+        assertThat(project.getIssueCount()).isEqualTo(2 + 3);
     }
 
     @Test

--- a/src/test/java/com/philips/research/bombar/core/domain/ProjectTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/ProjectTest.java
@@ -6,7 +6,6 @@
 package com.philips.research.bombar.core.domain;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/philips/research/bombar/core/domain/licenses/LicenseCheckerTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/licenses/LicenseCheckerTest.java
@@ -59,8 +59,8 @@ class LicenseCheckerTest {
 
     @Test
     void approvesCompatibleLicenses() {
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
-        child1.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child2));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
+        project.addRelationship(child1, child2, Relation.Relationship.INDEPENDENT);
 
         assertThat(checker.violations()).isEmpty();
         assertThat(project.getIssueCount()).isZero();
@@ -131,7 +131,7 @@ class LicenseCheckerTest {
     @Test
     void detectsIncompatibleSubpackage() {
         child1.setLicense(VIRAL);
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
 
         final var violations = checker.violations();
 
@@ -144,7 +144,7 @@ class LicenseCheckerTest {
 
     @Test
     void detectsMultiLicenseIncompatibleSubpackage() {
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
         parent.setLicense(String.format("(%s AND (%s))", LICENSE, OTHER));
         child1.setLicense(VIRAL);
 
@@ -159,7 +159,7 @@ class LicenseCheckerTest {
 
     @Test
     void detectsIncompatibleMultiLicenseSubpackage() {
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
         parent.setLicense(LICENSE);
         child1.setLicense(String.format("(%s AND (%s))", LICENSE, VIRAL));
 
@@ -174,7 +174,7 @@ class LicenseCheckerTest {
 
     @Test
     void detectsIncompatibleMultiChoiceLicenseSubpackage() {
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
         parent.setLicense(LICENSE);
         child1.setLicense(String.format("%s OR %s)", LICENSE, VIRAL));
 
@@ -186,7 +186,7 @@ class LicenseCheckerTest {
 
     @Test
     void detectsUnknownSubpackageOnlyOnce() {
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
         child1.setLicense("Unknown");
 
         assertThat(checker.violations()).hasSize(1);
@@ -198,7 +198,7 @@ class LicenseCheckerTest {
     @Test
     void detectsIncompatibleSubpackageForDistribution() {
         project.setDistribution(Project.Distribution.PROPRIETARY);
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
         child1.setLicense(VIRAL_DISTRIBUTION);
 
         final var violations = checker.violations();
@@ -212,7 +212,7 @@ class LicenseCheckerTest {
 
     @Test
     void detectsIncompatibleSubpackageForRelation() {
-        parent.addRelation(new Relation(Relation.Relationship.MODIFIED_CODE, child1));
+        project.addRelationship(parent, child1, Relation.Relationship.MODIFIED_CODE);
         child1.setLicense(VIRAL_RELATION);
 
         final var violations = checker.violations();
@@ -226,8 +226,8 @@ class LicenseCheckerTest {
 
     @Test
     void checksAllPackagesRecursively() {
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
-        child1.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child2));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
+        project.addRelationship(child1, child2, Relation.Relationship.INDEPENDENT);
         parent.setLicense("Unknown");
         child2.setLicense(VIRAL);
 
@@ -243,7 +243,7 @@ class LicenseCheckerTest {
 
     @Test
     void skipsPackagesBehindIrrelevantRelationship() {
-        parent.addRelation(new Relation(Relation.Relationship.IRRELEVANT, child1));
+        project.addRelationship(parent, child1, Relation.Relationship.IRRELEVANT);
         child1.setLicense(VIRAL);
 
         final var violations = checker.violations();
@@ -254,8 +254,8 @@ class LicenseCheckerTest {
     @Test
     void detectsIncompatibleChildLicensesForDistribution() {
         project.setDistribution(Project.Distribution.PROPRIETARY);
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child1));
-        parent.addRelation(new Relation(Relation.Relationship.INDEPENDENT, child2));
+        project.addRelationship(parent, child1, Relation.Relationship.INDEPENDENT);
+        project.addRelationship(parent, child2, Relation.Relationship.INDEPENDENT);
         child2.setLicense(VIRAL_DISTRIBUTION);
 
         final var violations = checker.violations();
@@ -269,8 +269,8 @@ class LicenseCheckerTest {
 
     @Test
     void detectsIncompatibleChildLicensesForRelation() {
-        parent.addRelation(new Relation(Relation.Relationship.MODIFIED_CODE, child1));
-        parent.addRelation(new Relation(Relation.Relationship.MODIFIED_CODE, child2));
+        project.addRelationship(parent, child1, Relation.Relationship.MODIFIED_CODE);
+        project.addRelationship(parent, child2, Relation.Relationship.MODIFIED_CODE);
         child2.setLicense(VIRAL_RELATION);
 
         final var violations = checker.violations();

--- a/src/test/java/com/philips/research/bombar/core/domain/licenses/LicensesTest.java
+++ b/src/test/java/com/philips/research/bombar/core/domain/licenses/LicensesTest.java
@@ -28,8 +28,8 @@ class LicensesTest {
     @BeforeEach
     void beforeEach() {
         project.addDependency(parent).addDependency(dynamicChild).addDependency(staticChild);
-        parent.addRelation(new Relation(Relation.Relationship.DYNAMIC_LINK, dynamicChild));
-        parent.addRelation(new Relation(Relation.Relationship.STATIC_LINK, staticChild));
+        project.addRelationship(parent, dynamicChild, Relation.Relationship.DYNAMIC_LINK);
+        project.addRelationship(parent, staticChild, Relation.Relationship.STATIC_LINK);
     }
 
     private void assertViolations(String... fragments) {

--- a/src/test/java/com/philips/research/bombar/core/spdx/SpdxParserTest.java
+++ b/src/test/java/com/philips/research/bombar/core/spdx/SpdxParserTest.java
@@ -6,10 +6,8 @@
 package com.philips.research.bombar.core.spdx;
 
 import com.philips.research.bombar.core.PersistentStore;
-import com.philips.research.bombar.core.domain.Dependency;
 import com.philips.research.bombar.core.domain.Package;
-import com.philips.research.bombar.core.domain.Project;
-import com.philips.research.bombar.core.domain.Relation;
+import com.philips.research.bombar.core.domain.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,6 +31,7 @@ class SpdxParserTest {
     private static final String TITLE = "Name";
     private static final URI REFERENCE = URI.create("maven/namespace/name");
     private static final String VERSION = "Version";
+    private static final Purl PURL = new Purl(REFERENCE, VERSION);
     private static final String LICENSE = "License";
 
     private final Project project = new Project(PROJECT_ID);
@@ -89,7 +88,7 @@ class SpdxParserTest {
                 "PackageName: " + TITLE,
                 "SPDXID: package",
                 "PackageLicenseConcluded: " + LICENSE,
-                "ExternalRef: PACKAGE-MANAGER purl pkg:" + REFERENCE + "@" + VERSION,
+                "ExternalRef: PACKAGE-MANAGER purl " + PURL,
                 "PackageVersion: Nope");
 
         parser.parse(spdx);
@@ -101,6 +100,7 @@ class SpdxParserTest {
         assertThat(dependency.getVersion()).isEqualTo(VERSION);
         assertThat(dependency.getTitle()).isEqualTo(TITLE);
         assertThat(dependency.getLicense()).isEqualTo(LICENSE);
+        assertThat(dependency.getPurl()).contains(PURL.toUri());
     }
 
     @Test
@@ -119,6 +119,7 @@ class SpdxParserTest {
         assertThat(dependency.getTitle()).isEqualTo(TITLE);
         assertThat(dependency.getVersion()).isEqualTo(VERSION);
         assertThat(dependency.getLicense()).isEqualTo(LICENSE);
+        assertThat(dependency.getPurl()).isEmpty();
     }
 
     @Test
@@ -157,7 +158,7 @@ class SpdxParserTest {
         parser.parse(spdxStream(
                 "PackageName: Name",
                 "SPDXID: 1",
-                "ExternalRef: PACKAGE-MANAGER purl pkg:" + REFERENCE + "@1.0",
+                "ExternalRef: PACKAGE-MANAGER purl " + PURL,
                 "PackageHomePage: http://example.com",
                 "PackageSupplier: Vendor",
                 "PackageSummary: <text>Summary</text>"));

--- a/src/test/java/com/philips/research/bombar/core/spdx/SpdxParserTest.java
+++ b/src/test/java/com/philips/research/bombar/core/spdx/SpdxParserTest.java
@@ -177,12 +177,6 @@ class SpdxParserTest {
 
     @Nested
     class RelationshipConversion {
-        @BeforeEach()
-        void beforeEach() {
-            when(store.createRelation(any(), any()))
-                    .thenAnswer((a) -> new Relation(a.getArgument(0), a.getArgument(1)));
-        }
-
         @Test
         void createsChildRelations() {
             parser.parse(spdxStream(

--- a/src/test/java/com/philips/research/bombar/persistence/PersistentDatabaseTest.java
+++ b/src/test/java/com/philips/research/bombar/persistence/PersistentDatabaseTest.java
@@ -26,7 +26,6 @@ class PersistentDatabaseTest {
     private static final URI REFERENCE = URI.create("namespace/name");
     private static final String TITLE = "Title";
     private static final String DEPENDENCY_ID = "DependencyId";
-    private static final String VERSION = "Version";
 
     @Autowired
     private PersistentDatabase database;

--- a/src/test/java/com/philips/research/bombar/persistence/PersistentDatabaseTest.java
+++ b/src/test/java/com/philips/research/bombar/persistence/PersistentDatabaseTest.java
@@ -104,9 +104,8 @@ class PersistentDatabaseTest {
     void storesRelations() {
         final var project = database.createProject();
         final var dependency = database.createDependency(project, DEPENDENCY_ID, TITLE);
-        dependency.addRelation(new Relation(Relation.Relationship.DYNAMIC_LINK, dependency));
-        dependency.addUsage(dependency);
         project.addDependency(dependency);
+        project.addRelationship(dependency, dependency, Relation.Relationship.DYNAMIC_LINK);
         flushEntityManager();
 
         //noinspection OptionalGetWithoutIsPresent


### PR DESCRIPTION
- Improve query performance by caching the Package URL per dependency.
- Improve query performance by caching the issue count per project.
- Clean up relationship handling.
- Extend existing db migration to generate dependency flags from existing data.