### PR TITLE
Fix(backend): Search performance for packages

### DIFF
--- a/src/main/java/com/philips/research/bombar/core/domain/DtoConverter.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/DtoConverter.java
@@ -76,6 +76,13 @@ abstract class DtoConverter {
     }
 
     public static PackageDto toDto(Package pkg) {
+        final PackageDto dto = toBaseDto(pkg);
+        dto.licenseExemptions.addAll(pkg.getLicenseExemptions());
+        Collections.sort(dto.licenseExemptions);
+        return dto;
+    }
+
+    public static PackageDto toBaseDto(Package pkg) {
         final var dto = new PackageDto();
         dto.reference = pkg.getReference();
         dto.name = pkg.getName();
@@ -83,8 +90,6 @@ abstract class DtoConverter {
         pkg.getVendor().ifPresent(vendor -> dto.vendor = vendor);
         pkg.getHomepage().ifPresent(url -> dto.homepage = url);
         pkg.getDescription().ifPresent(description -> dto.description = description);
-        dto.licenseExemptions.addAll(pkg.getLicenseExemptions());
-        Collections.sort(dto.licenseExemptions);
         return dto;
     }
 

--- a/src/main/java/com/philips/research/bombar/core/domain/PackageInteractor.java
+++ b/src/main/java/com/philips/research/bombar/core/domain/PackageInteractor.java
@@ -37,7 +37,7 @@ public class PackageInteractor implements PackageService {
     @Override
     public List<PackageDto> findPackages(String fragment) {
         final var results = store.findPackageDefinitions(fragment).stream()
-                .map(DtoConverter::toDto)
+                .map(DtoConverter::toBaseDto)
                 .collect(Collectors.toList());
         LOG.info("Search packages for '{}' returned {} results", fragment, results.size());
         return results;


### PR DESCRIPTION
Cause was inclusion of the exemptions list (=lazy loaded from the database),
although this is irrelevant info to list search results.