### PR TITLE
Fix filtering on dependencies for License

### DIFF
--- a/ui/lib/screens/project/dependencies_card.dart
+++ b/ui/lib/screens/project/dependencies_card.dart
@@ -83,7 +83,7 @@ class _DependenciesCardState extends State<DependenciesCard> {
             child: TextFilter(
               key: ValueKey('test'),
               onChanged: (filter) => setState(() {
-                _filter = filter;
+                _filter = filter.toLowerCase();
               }),
             ),
           ),


### PR DESCRIPTION
The bug on filtering with license, seems to be with casing.
