### PR TITLE
Use tree format for spdx-builder

### DIFF
--- a/.github/workflows/licenses.yml
+++ b/.github/workflows/licenses.yml
@@ -10,15 +10,27 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        java-version: '11.0.1' 
+        java-version: '11.0.13'
         distribution: 'zulu'
+
+    - name: Create dependencies list
+      run: |
+        ./mvnw dependency:tree 
+        ./mvnw dependency:tree > dependencies.txt
+
+    - name: Show dependencies.txt
+      run: |
+        cat dependencies.txt
 
     - name: Create spdx-file
       id: spdx-builder
-      uses: philips-software/spdx-action@v0.9.1
+      uses: philips-software/spdx-action@v0.9.1.1
       with:
         project: bom-bar
-        ort-version: 'latest'
+        mode: 'tree'
+        tree: dependencies.txt
+        format: maven
+
     - uses: actions/upload-artifact@v2.3.1
       with:
         name: licenses

--- a/.spdx-builder.yml
+++ b/.spdx-builder.yml
@@ -2,11 +2,6 @@ document:
   title: "BOM-bar Bill-of-Materials validator"
   organization: "Philips Research"
   comment: "This is a test file"
-projects:
-  - id: Maven:com.philips.research:BOM-bar:v0.3.0
-    purl: "pkg:maven/philips/bom-bar@v0.3.0"
-    excluded:
-      - "test*"
-      - "provided"
-      - "annotations"
-      - "archives"
+internal:
+  - com.philips.research:*
+


### PR DESCRIPTION
Use mvn tree input to generate SPDX file.

This file will NOT have any license information in it, only the SBOM.

Closes #84 
